### PR TITLE
chore: Remove "engines" in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,5 @@
     "eslint-plugin-react-refresh": "^0.4.6",
     "vite": "^5.2.0"
   },
-  "packageManager": "yarn@3.6.1",
-  "engines": {
-    "node": "20.13.1"
-  }
+  "packageManager": "yarn@3.6.1"
 }


### PR DESCRIPTION
Since we already have the information in `.tool-versions` this information in package.json is not needed (it whould also mean that this repo can only be used with the speficied version but any 20.x version should be fine)