### PR TITLE
ci: force git checkout on Uberspace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
             cd /home/${{ env.REMOTE_USER }}/serlo-editor-as-lti-tool/
-            git checkout ${{ github.ref_name }}
+            git checkout --force ${{ github.ref_name }}
             git pull
             yarn
             yarn build


### PR DESCRIPTION
If the local repo on Uberspace has modified files `git checkout` will fail. This will force the checkout. 

Downside: Local changes get deleted. @hugo What do you think? 