### PR TITLE
doc: add instructions to make clipboard and fullscreen work when in iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,9 @@ clipboard & allows full screen.
 <!-- Allow for only https://editor.serlo.org and https://editor.serlo-staging.dev -->
 <iframe
   allow="
-   clipboard-read https://editor.serlo.org;
-   clipboard-read https://editor.serlo-staging.dev;
-   clipboard-write https://editor.serlo.org;
-   clipboard-write https://editor.serlo-staging.dev;
-   fullscreen https://editor.serlo.org;
-   fullscreen https://editor.serlo-staging.dev
+   clipboard-read https://editor.serlo.org https://editor.serlo-staging.dev;
+   clipboard-write https://editor.serlo.org https://editor.serlo-staging.dev;
+   fullscreen https://editor.serlo.org https://editor.serlo-staging.dev
   "
 ></iframe>
 ```

--- a/README.md
+++ b/README.md
@@ -104,3 +104,26 @@ $ git add ./docker-entrypoint-initdb.d
 $ git commit
 $ git push
 ```
+
+# Embed Serlo editor in iframe
+
+Iframes can limit access to required functionality (especially for cross-origin
+embedding). Make sure the iframe embedding the Serlo editor allows access to the
+clipboard & allows full screen.
+
+```html
+<!-- Allow for all origins (can be unsave) -->
+<iframe allow="clipboard-read *; clipboard-write *; fullscreen *;"></iframe>
+
+<!-- Allow for only https://editor.serlo.org and https://editor.serlo-staging.dev -->
+<iframe
+  allow="
+   clipboard-read https://editor.serlo.org;
+   clipboard-read https://editor.serlo-staging.dev;
+   clipboard-write https://editor.serlo.org;
+   clipboard-write https://editor.serlo-staging.dev;
+   fullscreen https://editor.serlo.org;
+   fullscreen https://editor.serlo-staging.dev
+  "
+></iframe>
+```


### PR DESCRIPTION
Access to clipboard need permission in chrome based browsers. Fullscreen as well.  

See: 
- https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API (search for `clipboard-read`)
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#iframes 

I scanned the other available permissions but clipboard and fullscreen seem to be the only important ones. Do we need something else? 