### PR TITLE
fix(media): actually add tags

### DIFF
--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -15,7 +15,11 @@ import {
   editorPutEntity,
 } from './editor-route-handlers'
 import { getMariaDB } from './mariadb'
-import { mediaPresignedUrl, mediaProxy } from './media-route-handlers'
+import {
+  mediaPresignedUrl,
+  mediaProxy,
+  runTestUpload,
+} from './media-route-handlers'
 import { serverLog } from '../utils/server-log'
 
 const ltijsKey = config.LTIJS_KEY
@@ -117,6 +121,7 @@ const setup = async () => {
   app.get('/edusharing-embed/get', edusharing.get)
 
   app.get('/media/presigned-url', mediaPresignedUrl)
+  app.get('/media/test-upload', runTestUpload)
   app.use(mediaProxy)
 
   // Successful LTI resource link launch

--- a/src/backend/media-route-handlers.ts
+++ b/src/backend/media-route-handlers.ts
@@ -168,7 +168,7 @@ export async function runTestUpload(_req: Request, res: Response) {
   }
   const command = new GetObjectTaggingCommand(inputValues)
   const s3response = await s3Client.send(command)
-  serverLog(String(s3response.TagSet))
+  serverLog(s3response.TagSet)
 
   res.end('Done testing, check server logs for results')
 }

--- a/src/backend/media-route-handlers.ts
+++ b/src/backend/media-route-handlers.ts
@@ -110,7 +110,12 @@ export async function mediaPresignedUrl(req: Request, res: Response) {
   }
 
   const command = new PutObjectCommand(params)
-  const signedUrl = await getSignedUrl(s3Client, command, { expiresIn: 3600 })
+  const unhoistableHeaders: Set<string> = new Set(['x-amz-tagging'])
+
+  const signedUrl = await getSignedUrl(s3Client, command, {
+    expiresIn: 3600,
+    unhoistableHeaders,
+  })
 
   if (!signedUrl) {
     res.status(500).send('Could not generate signed URL')
@@ -141,6 +146,8 @@ export async function runTestUpload(_req: Request, res: Response) {
     body: file,
     headers: {
       'Content-Type': file.type,
+      'x-amz-tagging':
+        'editorVariant=test-uploads&editorHost=localhost:3000&userId=test',
       'Access-Control-Allow-Origin': '*',
     },
   }).catch((e) => {

--- a/src/backend/media-route-handlers.ts
+++ b/src/backend/media-route-handlers.ts
@@ -1,6 +1,7 @@
 import { createId } from '@paralleldrive/cuid2'
 import * as t from 'io-ts'
 import {
+  GetObjectTaggingCommand,
   PutObjectCommand,
   PutObjectCommandInput,
   S3Client,
@@ -9,6 +10,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 import type { Request, Response } from 'express'
 import config from '../utils/config'
+import { serverLog } from '../utils/server-log'
 
 const endpoint = config.S3_ENDPOINT
 const bucketName = config.BUCKET_NAME
@@ -119,4 +121,47 @@ export async function mediaPresignedUrl(req: Request, res: Response) {
   imgUrl.pathname = '/media/' + fileName
 
   res.json({ signedUrl, imgSrc: imgUrl.href })
+}
+
+export async function runTestUpload(_req: Request, res: Response) {
+  const presignedResponse = await fetch(
+    'http://localhost:3000/media/presigned-url?mimeType=image/png&editorVariant=test-uploads&userId=test'
+  )
+  const data = await presignedResponse.json()
+
+  // 1x1 pixel png
+  const base64Data =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z/C/HwAF/gL+Tf7XNQAAAABJRU5ErkJggg=='
+  const binaryData = atob(base64Data)
+  const byteArray = Uint8Array.from(binaryData, (char) => char.charCodeAt(0))
+  const file = new File([byteArray], '1x1.png', { type: 'image/png' })
+
+  await fetch(data.signedUrl, {
+    method: 'PUT',
+    body: file,
+    headers: {
+      'Content-Type': file.type,
+      'Access-Control-Allow-Origin': '*',
+    },
+  }).catch((e) => {
+    // eslint-disable-next-line no-console
+    console.error(e)
+  })
+
+  const checkResponse = await fetch(data.imgSrc)
+  const imageData = await checkResponse.blob()
+  serverLog('type: ' + imageData.type)
+  serverLog('size: ' + imageData.size)
+
+  const key = data.imgSrc.replace(config.MEDIA_BASE_URL + '/media/', '')
+
+  const inputValues = {
+    Bucket: 'editor-media-assets-development',
+    Key: key,
+  }
+  const command = new GetObjectTaggingCommand(inputValues)
+  const s3response = await s3Client.send(command)
+  serverLog(String(s3response.TagSet))
+
+  res.end('Done testing, check server logs for results')
 }

--- a/src/utils/server-log.ts
+++ b/src/utils/server-log.ts
@@ -1,4 +1,4 @@
-export function serverLog(message: string) {
+export function serverLog(...args: Parameters<typeof console.log>) {
   // eslint-disable-next-line no-console
-  console.log(`🐦 ${message}`)
+  console.log(...args)
 }


### PR DESCRIPTION
before the tags were not actually saved. 
it's a bit more complex since the tags need to be send via header from the client.
but if I understood everything right (and my testing confirms this so far) now the client sends the tagging header, but S3 won't accept it if it's not the same values as in the initial request to get the presigned url.

Follow up:
- needs changes in the editor code
- we could turn the testing endpoint into an actual test (and maybe remove the image after the test)