### PR TITLE
fix: set max width for content

### DIFF
--- a/src/frontend/Layout.tsx
+++ b/src/frontend/Layout.tsx
@@ -7,6 +7,8 @@ export function Layout({ children }: { children: React.ReactNode }) {
         display: 'flex',
         flexDirection: 'row',
         backgroundColor: 'white',
+        // Make horizontal scroll bar appear on small width. Plugin menu, plugin toolbar, ... need some space.
+        minWidth: '40rem',
       }}
     >
       <aside style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}></aside>
@@ -16,8 +18,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
           flexShrink: 1,
           flexBasis: maxContentWidth,
           maxWidth: `min(100%, ${maxContentWidth})`,
-          // Make horizontal scroll bar appear on small width. Plugin menu, plugin toolbar, ... need some space.
-          minWidth: '40rem',
           // Leave some space for editor UI that extends beyond (plugin toolbar, drag handle, ...)
           padding: '3rem',
         }}

--- a/src/frontend/Layout.tsx
+++ b/src/frontend/Layout.tsx
@@ -1,0 +1,30 @@
+// Centered & max-width content layout
+export function Layout({ children }: { children: React.ReactNode }) {
+  const maxContentWidth = '56rem'
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        backgroundColor: 'white',
+      }}
+    >
+      <aside style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}></aside>
+      <main
+        style={{
+          flexGrow: 1,
+          flexShrink: 1,
+          flexBasis: maxContentWidth,
+          maxWidth: `min(100%, ${maxContentWidth})`,
+          // Make horizontal scroll bar appear on small width. Plugin menu, plugin toolbar, ... need some space.
+          minWidth: '40rem',
+          // Leave some space for editor UI that extends beyond (plugin toolbar, drag handle, ...)
+          padding: '3rem',
+        }}
+      >
+        {children}
+      </main>
+      <aside style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}></aside>
+    </div>
+  )
+}

--- a/src/frontend/Layout.tsx
+++ b/src/frontend/Layout.tsx
@@ -9,6 +9,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         backgroundColor: 'white',
         // Make horizontal scroll bar appear on small width. Plugin menu, plugin toolbar, ... need some space.
         minWidth: '40rem',
+        overflowX: 'scroll',
       }}
     >
       <aside style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }}></aside>

--- a/src/frontend/SerloEditorWrapper.tsx
+++ b/src/frontend/SerloEditorWrapper.tsx
@@ -101,28 +101,21 @@ export default function SerloEditorWrapper(props: SerloContentProps) {
   }
 
   return (
-    <div
-      style={{ padding: '3rem', backgroundColor: 'white', minWidth: '600px' }}
+    <MemoSerloEditor
+      initialState={initialState}
+      onChange={(newState) => {
+        editorStateRef.current = JSON.stringify(newState)
+        setEditorState(editorStateRef.current)
+        setSavePending(true)
+      }}
+      editorVariant="lti-tool"
+      _testingSecret={testingSecret}
+      plugins={plugins}
+      _ltik={ltik}
     >
-      {/* <div style={{ color: 'grey' }}>
-        {savePending ? 'Ungespeicherte Änderungen' : 'Gespeichert'}
-      </div> */}
-      <MemoSerloEditor
-        initialState={initialState}
-        onChange={(newState) => {
-          editorStateRef.current = JSON.stringify(newState)
-          setEditorState(editorStateRef.current)
-          setSavePending(true)
-        }}
-        editorVariant="lti-tool"
-        _testingSecret={testingSecret}
-        plugins={plugins}
-        _ltik={ltik}
-      >
-        {(editor) => {
-          return <>{editor.element}</>
-        }}
-      </MemoSerloEditor>
-    </div>
+      {(editor) => {
+        return <>{editor.element}</>
+      }}
+    </MemoSerloEditor>
   )
 }

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -1,9 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
+import { Layout } from './Layout.tsx'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <Layout>
+      <App />
+    </Layout>
   </React.StrictMode>
 )


### PR DESCRIPTION
Tried to roughly match max width we have on serlo.org

Empty space will grow to the left/right making content centered when we have more space than max width.