### PR TITLE
Adjust regarding media upload and minor refactoring

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -23,8 +23,8 @@ MONGODB_URI=mongodb://localhost:27017/
 S3_ENDPOINT=https://s3.eu-central-3.ionoscloud.com/
 BUCKET_NAME=editor-media-assets-development
 BUCKET_REGION=eu-central-3
-BUCKET_ACCESS_KEY_ID=
-BUCKET_SECRET_ACCESS_KEY=
+BUCKET_ACCESS_KEY_ID=placeholder
+BUCKET_SECRET_ACCESS_KEY=placeholder
 MEDIA_BASE_URL=https://editor.serlo.dev #TODO: should be staging later
 
 # LTI platform: itslearning (staging)

--- a/e2e/tests/media.ts
+++ b/e2e/tests/media.ts
@@ -25,65 +25,71 @@ Scenario('Requesting media proxy with invalid url returns 400', ({ I }) => {
   I.sendGetRequest('http://localhost:3000/media/imaginary987.png')
   I.seeResponseCodeIs(403)
 })
+if (config.BUCKET_ACCESS_KEY_ID !== 'placeholder') {
+  Scenario(
+    'Media: Uploading image works and Metadata is written as expected',
+    async ({ I }) => {
+      I.amOnPage('http://localhost:3000')
 
-Scenario(
-  'Media: Uploading image works and Metadata is written as expected',
-  async ({ I }) => {
-    I.amOnPage('http://localhost:3000')
+      const presignedResponse = await fetch(
+        'http://localhost:3000/media/presigned-url?mimeType=image/png&editorVariant=test-uploads&userId=test&parentHost=localhost:3000'
+      )
+      const data = await presignedResponse.json()
+      I.assertStartsWith(
+        data.signedUrl,
+        'https://s3.eu-central-3.ionoscloud.com/editor-media-assets-development/test-uploads/'
+      )
+      I.assertStartsWith(data.fileUrl, 'https://editor.serlo.dev/media/')
 
-    const presignedResponse = await fetch(
-      'http://localhost:3000/media/presigned-url?mimeType=image/png&editorVariant=test-uploads&userId=test&parentHost=localhost:3000'
-    )
-    const data = await presignedResponse.json()
-    I.assertStartsWith(
-      data.signedUrl,
-      'https://s3.eu-central-3.ionoscloud.com/editor-media-assets-development/test-uploads/'
-    )
-    I.assertStartsWith(data.fileUrl, 'https://editor.serlo.dev/media/')
+      // // 1x1 pixel png
+      const base64Data =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z/C/HwAF/gL+Tf7XNQAAAABJRU5ErkJggg=='
+      const binaryData = atob(base64Data)
+      const byteArray = Uint8Array.from(binaryData, (char) =>
+        char.charCodeAt(0)
+      )
+      const file = new File([byteArray], '1x1.png', { type: 'image/png' })
 
-    // // 1x1 pixel png
-    const base64Data =
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADUlEQVR42mP8z/C/HwAF/gL+Tf7XNQAAAABJRU5ErkJggg=='
-    const binaryData = atob(base64Data)
-    const byteArray = Uint8Array.from(binaryData, (char) => char.charCodeAt(0))
-    const file = new File([byteArray], '1x1.png', { type: 'image/png' })
+      console.log(data.signedUrl)
 
-    console.log(data.signedUrl)
+      const uploadResponse = await fetch(data.signedUrl, {
+        method: 'PUT',
+        body: file,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': file.type,
+        },
+      }).catch((e) => {
+        console.error(e)
+        I.assertFalse(true) // fail test
+      })
 
-    const uploadResponse = await fetch(data.signedUrl, {
-      method: 'PUT',
-      body: file,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Content-Type': file.type,
-      },
-    }).catch((e) => {
-      console.error(e)
-      I.assertFalse(true) // fail test
-    })
+      if (!uploadResponse || uploadResponse.status !== 200) {
+        const res = uploadResponse as Response
+        console.log(res.headers)
+        console.log(res.status)
+        const text = await res.text()
+        console.log(text)
+        I.assertFalse(true) // fail test
+      }
 
-    if (!uploadResponse || uploadResponse.status !== 200) {
-      const res = uploadResponse as Response
-      console.log(res.headers)
-      console.log(res.status)
-      const text = await res.text()
-      console.log(text)
-      I.assertFalse(true) // fail test
+      I.sendGetRequest(data.fileUrl)
+      I.seeResponseCodeIsSuccessful()
+
+      const key = data.fileUrl.replace(config.MEDIA_BASE_URL + '/media/', '')
+
+      uploadedKeys.push(key)
+
+      const inputValues = {
+        Bucket: 'editor-media-assets-development',
+        Key: key,
+      }
+      const headCommand = new HeadObjectCommand(inputValues)
+      const metaResponse = await s3Client.send(headCommand)
+      I.assertEqual(
+        JSON.stringify(metaResponse.Metadata),
+        '{"content-type":"image/png","editorvariant":"test-uploads","parenthost":"localhost:3000","requesthost":"localhost:3000","userid":"test"}'
+      )
     }
-
-    I.sendGetRequest(data.fileUrl)
-    I.seeResponseCodeIsSuccessful()
-
-    const key = data.fileUrl.replace(config.MEDIA_BASE_URL + '/media/', '')
-
-    uploadedKeys.push(key)
-
-    const inputValues = { Bucket: 'editor-media-assets-development', Key: key }
-    const headCommand = new HeadObjectCommand(inputValues)
-    const metaResponse = await s3Client.send(headCommand)
-    I.assertEqual(
-      JSON.stringify(metaResponse.Metadata),
-      '{"content-type":"image/png","editorvariant":"test-uploads","parenthost":"localhost:3000","requesthost":"localhost:3000","userid":"test"}'
-    )
-  }
-)
+  )
+}

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -116,16 +116,15 @@ const setup = async () => {
   app.use(media.proxyMiddleware)
 
   // Successful LTI resource link launch
-  // @ts-expect-error @types/ltijs
-  ltijs.onConnect(async (idToken, req, res) => {
+  ltijs.onConnect((idToken, req, res) => {
     if (
       idToken.iss ===
         'https://repository.staging.cloud.schulcampus-rlp.de/edu-sharing' ||
       idToken.iss === 'http://localhost:8100/edu-sharing'
     ) {
-      await onConnectEdusharing(idToken, req, res)
+      void onConnectEdusharing(idToken, req, res)
     } else {
-      onConnectDefault(idToken, req, res)
+      void onConnectDefault(idToken, req, res)
     }
   }, {})
 

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -117,11 +117,7 @@ const setup = async () => {
 
   // Successful LTI resource link launch
   ltijs.onConnect((idToken, req, res) => {
-    if (
-      (config.ENVIRONMENT === 'staging' &&
-        idToken.iss === config.EDUSHARING_RLP_URL) ||
-      idToken.iss === 'http://localhost:8100/edu-sharing'
-    ) {
+    if (idToken.iss.includes('edu-sharing')) {
       void onConnectEdusharing(idToken, req, res)
     } else {
       void onConnectDefault(idToken, req, res)

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -118,8 +118,8 @@ const setup = async () => {
   // Successful LTI resource link launch
   ltijs.onConnect((idToken, req, res) => {
     if (
-      idToken.iss ===
-        'https://repository.staging.cloud.schulcampus-rlp.de/edu-sharing' ||
+      (config.ENVIRONMENT === 'staging' &&
+        idToken.iss === config.EDUSHARING_RLP_URL) ||
       idToken.iss === 'http://localhost:8100/edu-sharing'
     ) {
       void onConnectEdusharing(idToken, req, res)


### PR DESCRIPTION
After https://github.com/serlo/serlo-editor-as-lti-tool/pull/170 the env vars regarding bucket cannot be empty anymore. 
That way we avoided missing to set this variables that are actually very important for the app. 
On the other hand, the repo needs now some adjusts in order to improve the development workflow.

And since we decided not to show a URL of a partner in plain text (even though it is not a secret by itself), I've hidden it (but, to say the truth, the same value can be found in another parts of the code).

Besides that, a minor refactoring was made.