### PR TITLE
fix: schedule new save even if one is ongoing and taking some time to finish

### DIFF
--- a/src/backend/editor-route-handlers.ts
+++ b/src/backend/editor-route-handlers.ts
@@ -66,7 +66,7 @@ export async function putEntity(req: Request, res: Response) {
 
   // Modify entity with decodedAccessToken.entityId in database
   await database.mutate('UPDATE lti_entity SET content = ? WHERE id = ?', [
-    req.body.editorState,
+    JSON.stringify(req.body.editorState),
     decodedAccessToken.entityId,
   ])
   logger.info(


### PR DESCRIPTION
**Before**
Any changes made by the user during saving did not schedule another auto save. -> Content can be lost. 

**After**
New method that ensures we schedule a save event in this scenario. 