### PR TITLE
fix(mocks): prevent idtoken expiration while selecting resource to embed from edu-sharing

### DIFF
--- a/mocks/edusharing/server.ts
+++ b/mocks/edusharing/server.ts
@@ -236,9 +236,7 @@ export class EdusharingServer {
 
         const embedType = req.query['embed-type']
 
-        const decodedJwt = await jose.decodeJwt(idToken)
-
-        const idTokenDecoded = decodedJwt.payload
+        const idTokenDecoded = jose.decodeJwt(idToken)
         const idTokenType = t.type({
           'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings':
             t.type({
@@ -320,7 +318,7 @@ export class EdusharingServer {
       )
         return
 
-      const idToken = req.query.id_token
+      const idToken = req.body.id_token
       if (typeof idToken !== 'string') {
         res.status(400).send('id_token is undefined')
         return

--- a/mocks/edusharing/server.ts
+++ b/mocks/edusharing/server.ts
@@ -236,17 +236,9 @@ export class EdusharingServer {
 
         const embedType = req.query['embed-type']
 
-        const serloEditorJwks = jose.createRemoteJWKSet(
-          new URL(urlJoin(editorUrl, 'edusharing-embed/keys'))
-        )
+        const decodedJwt = await jose.decodeJwt(idToken)
 
-        const verifyResult = await jose.jwtVerify(idToken, serloEditorJwks, {
-          audience: edusharingMockClientId,
-          issuer: editorUrl,
-          subject: this.user,
-        })
-
-        const idTokenDecoded = verifyResult.payload
+        const idTokenDecoded = decodedJwt.payload
         const idTokenType = t.type({
           'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings':
             t.type({
@@ -327,9 +319,24 @@ export class EdusharingServer {
         })
       )
         return
+
+      const idToken = req.query.id_token
+      if (typeof idToken !== 'string') {
+        res.status(400).send('id_token is undefined')
+        return
+      }
+
+      const serloEditorJwks = jose.createRemoteJWKSet(
+        new URL(urlJoin(editorUrl, 'edusharing-embed/keys'))
+      )
+
+      await jose.jwtVerify(idToken, serloEditorJwks, {
+        audience: edusharingMockClientId,
+        issuer: editorUrl,
+        subject: this.user,
+      })
+
       const embedTypes = ['image', 'word']
-      const searchParams = new URLSearchParams()
-      searchParams.append('id_token', req.body.id_token)
 
       res.setHeader('Content-Type', 'text/html')
       res.send(

--- a/src/backend/edusharing/jwt-helpers.ts
+++ b/src/backend/edusharing/jwt-helpers.ts
@@ -93,7 +93,7 @@ export function signJwtWithBase64Key(
   payload: Omit<jwt.JwtPayload, 'iat'>,
   expireAfterSeconds?: number
 ) {
-  const defaultExpireAfterSeconds = 15
+  const defaultExpireAfterSeconds = 60
 
   return jwt.sign(
     { ...payload, iat: Math.floor(Date.now() / 1000) },


### PR DESCRIPTION
Changes: Moves the code for verifying the JWT. 
Before: It was checked when selecting a resource. But by then the token could already have expired if the user waits long enough or the automatic tests take long enough. 
Now: It is checked when edu-sharing opens.