### PR TITLE
Fix: edu-sharing deployment save

### DIFF
--- a/src/backend/editor-route-handlers.ts
+++ b/src/backend/editor-route-handlers.ts
@@ -129,17 +129,21 @@ export async function onConnect(
         `Invalid LTI custom claim during launch of Serlo editor. Was: ${JSON.stringify(custom)}`
       )
 
-    const mariadb = await getMariaDb()
+    const entity = await getEntity(resourceLinkId)
+    async function getEntity(resourceLinkId: string) {
+      if (config.IS_EDUSHARING_DEPLOYMENT) {
+        return await edusharingApi.getEntity(idToken, custom)
+      }
+      const mariadb = await getMariaDb()
 
-    const entity = config.IS_EDUSHARING_DEPLOYMENT
-      ? await edusharingApi.getEntity(idToken, custom)
-      : await mariadb.createOrGetEntity({
-          custom,
-          idToken,
-          platform,
-          resourceLinkId,
-          user,
-        })
+      return await mariadb.createOrGetEntity({
+        custom,
+        idToken,
+        platform,
+        resourceLinkId,
+        user,
+      })
+    }
 
     const editorMode = getEditorMode(idToken, custom, isEdusharing)
 
@@ -311,7 +315,7 @@ export async function putEntity(
     const isEdusharing = idToken.iss.includes('edu-sharing')
     if (isEdusharing) {
       edusharingApi
-        .putEntity(contentString, res)
+        .putContent(contentString, res)
         // Do not forward error to express. To the user, a failed save to edu-sharing is still considered successful.
         .catch(() => {})
     }

--- a/src/backend/edusharing/edusharing-api.ts
+++ b/src/backend/edusharing/edusharing-api.ts
@@ -3,9 +3,10 @@ import { IdToken } from '../types/idtoken'
 import { getEdusharingInfo } from './get-edusharing-info'
 import jwt from 'jsonwebtoken'
 import { createAndLogError } from '../../utils/logger'
+import type { GetEntityBody } from '../../frontend/types/get-entity-body'
 
 export const edusharingApi = {
-  async getEntity(idToken: IdToken, custom: unknown) {
+  async getEntity(idToken: IdToken, custom: unknown): Promise<GetEntityBody> {
     const {
       appId,
       dataToken,
@@ -39,9 +40,13 @@ export const edusharingApi = {
 
     const stringifiedDocumentState = await edusharingResponse.text()
 
+    // No exising content
+    if (stringifiedDocumentState.length === 0)
+      return { id: nodeId, content: null }
+
     return { id: nodeId, content: stringifiedDocumentState }
   },
-  async putEntity(contentString: string, res: Response) {
+  async putContent(contentString: string, res: Response) {
     const {
       appId,
       dataToken,

--- a/src/backend/edusharing/edusharing-api.ts
+++ b/src/backend/edusharing/edusharing-api.ts
@@ -40,11 +40,12 @@ export const edusharingApi = {
 
     const stringifiedDocumentState = await edusharingResponse.text()
 
-    // No exising content
-    if (stringifiedDocumentState.length === 0)
-      return { id: nodeId, content: null }
+    const noContent = stringifiedDocumentState.length === 0
 
-    return { id: nodeId, content: stringifiedDocumentState }
+    return {
+      id: nodeId,
+      content: noContent ? null : stringifiedDocumentState,
+    }
   },
   async putContent(contentString: string, res: Response) {
     const {

--- a/src/backend/edusharing/edusharing-deployment.ts
+++ b/src/backend/edusharing/edusharing-deployment.ts
@@ -61,7 +61,7 @@ export async function putEntity(
 
     const contentString = JSON.stringify(req.body.editorState)
 
-    await edusharingApi.putEntity(contentString, res)
+    await edusharingApi.putContent(contentString, res)
 
     res.sendStatus(200)
   } catch (error) {

--- a/src/backend/mariadb.ts
+++ b/src/backend/mariadb.ts
@@ -63,11 +63,7 @@ const mariaDb = {
     // (B) A copy of an existing entity on edu-sharing
     // Here, we try to get an existing entity from edu-sharing. If none exists, we have (A) and set the initial content to null. If one exists, we have (B) and use the state to initialize the new entity in our database.
     // This is a workaround for a known limitation in LTI. See: https://www.imsglobal.org/lti-course-copy-road-nowhere
-    const initialContentString = await getInitialContent(
-      platform,
-      idToken,
-      custom
-    )
+    const initialContent = await getInitialContent(platform, idToken, custom)
     async function getInitialContent(
       platform: string,
       idToken: IdToken,
@@ -98,7 +94,7 @@ const mariaDb = {
         resourceLinkId,
         customClaimId,
         edusharingNodeId,
-        initialContentString,
+        initialContent,
         user,
         userWhenCreated,
       ]
@@ -145,7 +141,7 @@ const mariaDb = {
 
     return { ...entity, id: entity.id.toString() }
   },
-  async setContent(id: number, content: unknown) {
+  async setContent(id: number, content: string) {
     await pool.query<ResultSetHeader>(
       'UPDATE lti_entity SET content = ? WHERE id = ?',
       [content, id]


### PR DESCRIPTION
Edu-sharing returns an empty string if there is no existing content. 