### PR TITLE
chore: Remove unnecessary code

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,12 +18,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - id: version
-        uses: salsify/action-detect-and-tag-new-version@v2
+      - uses: salsify/action-detect-and-tag-new-version@v2
         with:
           tag-template: '{VERSION}'
-          version-command: |
-            jq ".version" --raw-output < package.json
 
   build-and-push-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The name doesn't say anything and the default behavior of the action is to look at the `package.json`.
