### PR TITLE
fix: edu-sharing embed with mock in docker

### DIFF
--- a/mocks/edusharing/server.ts
+++ b/mocks/edusharing/server.ts
@@ -320,7 +320,14 @@ export class EdusharingServer {
       }
 
       const serloEditorJwks = jose.createRemoteJWKSet(
-        new URL(urlJoin(editorUrl, 'edusharing-embed/keys'))
+        new URL(
+          urlJoin(
+            config.ENVIRONMENT === 'edusharing'
+              ? 'http://app:3000/'
+              : editorUrl,
+            'edusharing-embed/keys'
+          )
+        )
       )
 
       await jose.jwtVerify(idToken, serloEditorJwks, {


### PR DESCRIPTION
The mock needs to directly reach the express server for the keys. 