### PR TITLE
refactor: not hardcode edu-sharing mock

### DIFF
--- a/.env.image
+++ b/.env.image
@@ -35,4 +35,16 @@ BUCKET_SECRET_ACCESS_KEY=placeholder
 
 OPENAI_API_KEY=placeholder
 
+# Register edu-sharing
+EDUSHARING_RLP_URL=http://mocks:8100/edu-sharing
+EDUSHARING_RLP_NAME=edusharing-mock
+EDUSHARING_RLP_AUTHENTICATION_ENDPOINT=http://mocks:8100/edu-sharing/rest/ltiplatform/v13/auth
+EDUSHARING_RLP_ACCESS_TOKEN_ENDPOINT=http://mocks:8100/edu-sharing/rest/ltiplatform/v13/token
+EDUSHARING_RLP_KEYSET_ENDPOINT=http://mocks:8100/edu-sharing/rest/lti/v13/jwks
+SERLO_EDITOR_CLIENT_ID_ON_EDUSHARING_RLP=piQ0JV8O880ZrVt
+EDUSHARING_RLP_LOGIN_ENDPOINT=http://mocks:8100/edu-sharing/rest/lti/v13/oidc/login_initiations
+EDUSHARING_RLP_LAUNCH_ENDPOINT=http://mocks:8100/edu-sharing/rest/lti/v13/lti13
+EDUSHARING_RLP_DETAILS_ENDPOINT=http://mocks:8100/edu-sharing/rest/lti/v13/details
+EDUSHARING_RLP_CLIENT_ID_ON_SERLO_EDITOR=edusharing-mock
+
 # Keep an empty line at the end

--- a/src/backend/util/register-lti-platforms.ts
+++ b/src/backend/util/register-lti-platforms.ts
@@ -114,30 +114,6 @@ export async function registerLtiPlatforms() {
   }
 
   if (config.ENVIRONMENT === 'edusharing') {
-    // Register platform: edusharing mock
-    const edusharingMockPlatform = await registerPlatform({
-      url: 'http://mocks:8100/edu-sharing',
-      name: 'edusharing-mock',
-      clientId: 'piQ0JV8O880ZrVt', // The ID for this LTI tool on the LTI platform
-      authenticationEndpoint:
-        'http://mocks:8100/edu-sharing/rest/ltiplatform/v13/auth',
-      accesstokenEndpoint:
-        'http://mocks:8100/edu-sharing/rest/ltiplatform/v13/token',
-      key: 'http://mocks:8100/edu-sharing/rest/lti/v13/jwks',
-    })
-    if (edusharingMockPlatform) {
-      edusharingAsToolConfigs.push({
-        issWhenEdusharingLaunchedSerloEditor: 'http://mocks:8100/edu-sharing',
-        loginEndpoint:
-          'http://mocks:8100/edu-sharing/rest/lti/v13/oidc/login_initiations',
-        launchEndpoint: 'http://mocks:8100/edu-sharing/rest/lti/v13/lti13',
-        clientId: edusharingMockClientId,
-        detailsEndpoint: 'http://mocks:8100/edu-sharing/rest/lti/v13/details',
-        keysetEndpoint: 'http://mocks:8100/edu-sharing/rest/lti/v13/jwks',
-      })
-      logger.info(`Registered tool: edusharing-mock`)
-    }
-    // Register platform: edu-sharing (RLP)
     const edusharingPlatform = await registerPlatform({
       url: config.EDUSHARING_RLP_URL,
       name: config.EDUSHARING_RLP_NAME,
@@ -155,7 +131,7 @@ export async function registerLtiPlatforms() {
         detailsEndpoint: config.EDUSHARING_RLP_DETAILS_ENDPOINT,
         keysetEndpoint: config.EDUSHARING_RLP_KEYSET_ENDPOINT,
       })
-      logger.info('Registered tool: edu-sharing (RLP)')
+      logger.info(`Registered: ${config.EDUSHARING_RLP_URL}`)
     }
   }
 }


### PR DESCRIPTION
In local development the mock is registered. In a deployment the docker container is supplied with an actual edu-sharing. 